### PR TITLE
Show multi-category commits under each category

### DIFF
--- a/index.js
+++ b/index.js
@@ -499,14 +499,14 @@
             const categories = [];
 
             commits.forEach(commit => {
-                const categoryResult = categoryRegex.exec(commit.commit.message);
-                const category = categoryResult ? categoryResult[1] : "Uncategorized";
+                const commitCategories = categorizeCommitMessage(commit.commit.message);
 
-                const hasCategory = categories[category] !== undefined;
+                commitCategories.forEach(category => {
+                    const hasCategory = categories[category] !== undefined;
+                    if (!hasCategory) categories[category] = [];
 
-                if (!hasCategory) categories[category] = [];
-
-                categories[category].push(commit);
+                    categories[category].push(commit);
+                });
             });
 
             // For the sort: https://stackoverflow.com/a/45544166
@@ -699,6 +699,21 @@
             fetchFailed();
             enableDateButtons();
         }
+    }
+
+    function categorizeCommitMessage(message) {
+        const categoryResult = categoryRegex.exec(message);
+        if (!categoryResult)
+            return ["Uncategorized"];
+
+        const categoryString = categoryResult[1];
+        let categories = [];
+        if (categoryString.indexOf("+") >= 0)
+            categories.push(...categoryString.split("+"));
+        else
+            categories.push(categoryString);
+
+        return categories;
     }
 
     const retryButtons = document.querySelectorAll(".retry-fetch");


### PR DESCRIPTION
A common kind of category in SerenityOS commits are the multi-category
specifiers, when a commit touches more than one area of the system.
There's a standardized way to specify those with a "+", an example would
be "LibJS+Kernel+AK: ...".

This change breaks up such commit categories, so that commits get
categorized under each individual category. In the above example, the
commit would appear under "LibJS" and "Kernel" and "AK". While this does
duplicate commits and make some categories larger, it removes the weird
single-commit "+" headers on the page, making it easier to read and
navigate.

For achieving this, a new function that extracts categories from commit
titles was created, which is capable of returning more than one
category.