### PR TITLE
Represent hierarchical commits properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -747,11 +747,12 @@
                 } else {
                     const [firstSubCategory, lowerCategories] = category.split("/", 2);
                     const lcFirstSubCategory = firstSubCategory.toLowerCase();
-                    if (!this.#subCategories.has(lcFirstSubCategory))
+                    if (!this.#subCategories.has(lcFirstSubCategory)) {
                         this.#subCategories.set(
                             lcFirstSubCategory,
                             new Category(this, firstSubCategory)
                         );
+                    }
                     this.#subCategories
                         .get(lcFirstSubCategory)
                         .insertInto(commit, [lowerCategories]);


### PR DESCRIPTION
It's common practice to use hierarchical categories for commits,
especially in Kernel and all categories that have tests. An example
would be "Kernel/X86/PCI". These categories are now represented with
hierarchical accordions, which can also arbitrarily nest. Due to the
nature of non-\<li\>'s in \<ul\>'s, the sub-categories appear after all the
direct commits of the categories. In my opinion however, that's one of
the best designs and it doesn't need to change.

For this change, the entire category system was moved to a Category
class which keeps track of this hierarchy during page generation.

An auxiliary change is case-insensitiveness for categories. Especially
programs that have a lower-case name are commonly written that way by
some contributors, which would previously make them appear under
separate categories.