### PR TITLE
Add top margin to first accordion element

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,9 @@
                 background: var(--color-background-alt);
                 color: var(--color-text);
             }
+            .accordion-item:first-of-type {
+                margin-top: 1rem;
+            }
 
             .accordion-button:not(.collapsed) {
                 background: var(--color-revealed-accordion);


### PR DESCRIPTION
For the new nested accordions, it was pointed out that they are located
very close vertically to the last commits of the parent category. This
simple CSS change adds some top margin to the first accordion element of
each list.