### PR TITLE
Handle revert commits and show linked commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,6 @@ jobs:
 
       - name: Check Prettier Version
         run: prettier --version
-      
+
       - name: Run Prettier
         run: prettier --check index.js

--- a/index.html
+++ b/index.html
@@ -311,6 +311,15 @@
                                 </h5>
                                 <pre class="card-text"></pre>
                             </div>
+                            <div class="card card-body mt-2 linked-commits">
+                                <h5>Linked commits</h5>
+                                <template id="link">
+                                    <div class="d-flex align-items-center">
+                                        <span class="sha"></span>
+                                        <a target="_blank" rel="noopener noreferrer" class="ms-2 link"></a>
+                                    </div>
+                                </template>
+                            </div>
                         </div>
                     </template>
                 </main>

--- a/index.html
+++ b/index.html
@@ -298,10 +298,11 @@
                     <template id="commit-element-template">
                         <li class="d-flex align-items-center">
                             <a target="_blank" rel="noopener noreferrer"></a>
+                            <div class="badge bg-danger ms-2">Revert</div>
                             <button class="btn btn-primary small-button ms-2" type="button" data-bs-toggle="collapse" aria-expanded="false">Details</button>
                         </li>
                         <div class="collapse">
-                            <div class="card card-body mt-2">
+                            <div class="card card-body mt-2 details">
                                 <h5 class="card-title d-flex align-items-center">
                                     <img class="lazyload img-fluid rounded author-image" width="20" height="20" />
                                     <span class="ms-2 author-name"></span>

--- a/index.js
+++ b/index.js
@@ -641,9 +641,9 @@
                 detailsButtonElement.dataset.bsTarget = `#${detailsId}`;
                 detailsButtonElement.setAttribute("aria-controls", detailsId);
 
-                const commitDetailsElement = commitElements.querySelector("div.collapse");
-                commitDetailsElement.id = detailsId;
-                const committerDetailsElement = commitDetailsElement.querySelector("div.details");
+                const commitCollapseElement = commitElements.querySelector("div.collapse");
+                commitCollapseElement.id = detailsId;
+                const committerDetailsElement = commitCollapseElement.querySelector("div.details");
 
                 const authorName = committerDetailsElement.querySelector("span.author-name");
                 const authorImage = committerDetailsElement.querySelector("img.author-image");
@@ -707,7 +707,7 @@
                     committerNameElement.remove();
                 }
 
-                const commitMessageElement = commitDetailsElement.querySelector("div > pre");
+                const commitMessageElement = commitCollapseElement.querySelector("div > pre");
 
                 if (messageParts.length > 1) {
                     messageParts.forEach((part, index) => {
@@ -718,6 +718,35 @@
                     });
                 } else {
                     committerDetailsElement.classList.add("mb-0");
+                }
+
+                const linkedCommits = [];
+
+                for (const otherCommit of commits) {
+                    if (commit.commit.message.includes(otherCommit.sha)) {
+                        linkedCommits.push(otherCommit);
+                    }
+                }
+
+                const linkedCommitsElement =
+                    commitCollapseElement.querySelector("div.linked-commits");
+                const linkElements = linkedCommitsElement.querySelector("template#link");
+
+                for (const linkedCommit of linkedCommits) {
+                    const linkElement = linkElements.content.cloneNode(true);
+
+                    const sha = linkElement.querySelector("span.sha");
+                    const link = linkElement.querySelector("a.link");
+
+                    sha.textContent = linkedCommit.sha;
+                    link.href = linkedCommit.html_url;
+                    link.textContent = linkedCommit.commit.message.split("\n")[0];
+
+                    linkedCommitsElement.appendChild(linkElement);
+                }
+
+                if (linkedCommits.length === 0) {
+                    linkedCommitsElement.remove();
                 }
 
                 // We need to do this last as the array spread removes the children from the HTMLCollection.


### PR DESCRIPTION
This pull request adds handling for `Revert "previous commit message"` commits and shows a all commits referenced by their full sha in a seperate list to make looking them up a lot easier :^)

![image](https://user-images.githubusercontent.com/42888162/151438414-ad3f8563-e1c6-416a-ae5d-8b6d6cafdc71.png)

![image](https://user-images.githubusercontent.com/42888162/151438569-4810e00c-fd63-4e80-91b7-593fa8bbf4fa.png)
